### PR TITLE
Revert PR #8: remove Parent hierarchy handling from physics systems

### DIFF
--- a/Assets/ECSPhysics2D/CHANGELOG.md
+++ b/Assets/ECSPhysics2D/CHANGELOG.md
@@ -5,11 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on \[Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to \[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## \[0.1.5] - 2026-04-09
+
+### Removed
+
+###### Reverted the changes introduced in v0.1.3. The fix to accommodate parent->child relationships introduced additional problems. The correct design is for all physics entities to be root entities (no `Parent`), using Box2D joints to express physical relationships instead of ECS transform hierarchy
+
 ## \[0.1.4] - 2026-03-31
 
 ### Added
 
 ###### Add a computed `Normal` variable to the `ClosestPointResult`. Normal is computed by geometry in `ClosestPointQuerySystem`.
+
+## \[0.1.3] - 2026-03-18
+
+### Fixed
+
+###### Fix for proper ECS parent->child relationship recognition, and appropriate `LocalToWorld` position computation
+
 ## \[0.1.2] - 2026-03-12
 
 ### Fixed

--- a/Assets/ECSPhysics2D/CHANGELOG.md
+++ b/Assets/ECSPhysics2D/CHANGELOG.md
@@ -10,13 +10,6 @@ and this project adheres to \[Semantic Versioning](https://semver.org/spec/v2.0.
 ### Added
 
 ###### Add a computed `Normal` variable to the `ClosestPointResult`. Normal is computed by geometry in `ClosestPointQuerySystem`.
-
-## \[0.1.3] - 2026-03-18
-
-### Fixed
-
-###### Fix for proper ECS parent->child relationship recognition, and appropriate `LocalToWorld` position computation
-
 ## \[0.1.2] - 2026-03-12
 
 ### Fixed

--- a/Assets/ECSPhysics2D/Runtime/Core/Systems/BuildPhysicsWorldSystem.cs
+++ b/Assets/ECSPhysics2D/Runtime/Core/Systems/BuildPhysicsWorldSystem.cs
@@ -1,7 +1,6 @@
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Entities;
-using Unity.Mathematics;
 using Unity.Transforms;
 using UnityEngine.LowLevelPhysics2D;
 
@@ -10,15 +9,9 @@ namespace ECSPhysics2D
   /// <summary>
   /// Builds/Updates the physics world from ECS components.
   /// Runs before simulation to sync ECS state TO physics.
-  ///
+  /// 
   /// Supports multi-world: each body is created in the world specified by
   /// PhysicsBodyComponent.WorldIndex.
-  ///
-  /// Position/rotation at body creation: if the entity has a Parent, LocalToWorld
-  /// (world-space) is used so the physics body is placed correctly in the hierarchy.
-  /// For root entities (no Parent), LocalTransform is used directly. This lets
-  /// runtime-spawned root entities (which may not have LocalToWorld yet) initialize
-  /// on the same frame they are created.
   /// </summary>
   [UpdateInGroup(typeof(FixedStepSimulationSystemGroup))]
   [UpdateBefore(typeof(PhysicsSimulationSystem))]
@@ -26,8 +19,6 @@ namespace ECSPhysics2D
   public partial struct BuildPhysicsWorldSystem : ISystem
   {
     private EntityQuery uninitializedBodies;
-    private ComponentLookup<Parent> _parentLookup;
-    private ComponentLookup<LocalToWorld> _localToWorldLookup;
 
     public void OnCreate(ref SystemState state)
     {
@@ -37,9 +28,6 @@ namespace ECSPhysics2D
           ComponentType.ReadWrite<PhysicsBodyComponent>(),
           ComponentType.Exclude<PhysicsBodyInitialized>()
       );
-
-      _parentLookup = state.GetComponentLookup<Parent>(isReadOnly: true);
-      _localToWorldLookup = state.GetComponentLookup<LocalToWorld>(isReadOnly: true);
     }
 
     [BurstCompile]
@@ -48,34 +36,12 @@ namespace ECSPhysics2D
       if (!SystemAPI.TryGetSingleton<PhysicsWorldSingleton>(out var singleton))
         return;
 
-      _parentLookup.Update(ref state);
-      _localToWorldLookup.Update(ref state);
-
       // Step 1: Create new physics bodies (routed to correct world by WorldIndex)
       CreateNewPhysicsBodies(ref state, singleton);
 
       // Step 2: Sync Kinematic/Static transforms TO physics
       SyncKinematicTransforms(ref state);
       SyncStaticTransforms(ref state);
-    }
-
-    // Returns world-space position and rotation for an entity.
-    // If the entity has a Parent, LocalToWorld is used (world-space).
-    // Otherwise, LocalTransform is used directly (local == world for root entities).
-    private void GetWorldSpacePosRot(
-        Entity entity,
-        in LocalTransform transform,
-        out float2 position,
-        out float rotation)
-    {
-      if (_parentLookup.HasComponent(entity) &&
-          _localToWorldLookup.TryGetComponent(entity, out var ltw)) {
-        position = ltw.Position.xy;
-        rotation = PhysicsUtility.GetRotationZ(new quaternion(ltw.Value)).angle;
-      } else {
-        position = transform.Position.xy;
-        rotation = PhysicsUtility.GetRotationZ(transform.Rotation).angle;
-      }
     }
 
     [BurstCompile]
@@ -99,13 +65,11 @@ namespace ECSPhysics2D
 
         var physicsWorld = singleton.GetWorld(worldIndex);
 
-        GetWorldSpacePosRot(entity, transform.ValueRO, out var position, out var rotation);
-
         var bodyDef = new PhysicsBodyDefinition
         {
           type = PhysicsBody.BodyType.Dynamic,
-          position = position,
-          rotation = new PhysicsRotate(rotation),
+          position = transform.ValueRO.Position.xy,
+          rotation = PhysicsUtility.GetRotationZ(transform.ValueRO.Rotation),
           fastCollisionsAllowed = bodyComponent.ValueRO.EnableCCD,
           linearVelocity = bodyComponent.ValueRO.InitialLinearVelocity,
           angularVelocity = bodyComponent.ValueRO.InitialAngularVelocity,
@@ -122,7 +86,7 @@ namespace ECSPhysics2D
         // Store entity reference in userData for callbacks
         bodyComponent.ValueRW.Body.SetEntityUserData(entity);
 
-        // Mark as initialized and preserve world-space Z position and scale
+        // Mark as initialized and preserve Z position
         ecb.AddComponent<PhysicsBodyInitialized>(entity);
         ecb.AddComponent(entity, new PhysicsTransformPreservation
         {
@@ -146,13 +110,11 @@ namespace ECSPhysics2D
 
         var physicsWorld = singleton.GetWorld(worldIndex);
 
-        GetWorldSpacePosRot(entity, transform.ValueRO, out var position, out var rotation);
-
         var bodyDef = new PhysicsBodyDefinition
         {
           type = PhysicsBody.BodyType.Kinematic,
-          position = position,
-          rotation = new PhysicsRotate(rotation),
+          position = transform.ValueRO.Position.xy,
+          rotation = PhysicsUtility.GetRotationZ(transform.ValueRO.Rotation),
           fastCollisionsAllowed = bodyComponent.ValueRO.EnableCCD,
           enabled = true
         };
@@ -183,13 +145,11 @@ namespace ECSPhysics2D
 
         var physicsWorld = singleton.GetWorld(worldIndex);
 
-        GetWorldSpacePosRot(entity, transform.ValueRO, out var position, out var rotation);
-
         var bodyDef = new PhysicsBodyDefinition
         {
           type = PhysicsBody.BodyType.Static,
-          position = position,
-          rotation = new PhysicsRotate(rotation),
+          position = transform.ValueRO.Position.xy,
+          rotation = PhysicsUtility.GetRotationZ(transform.ValueRO.Rotation),
           enabled = true
         };
 
@@ -212,18 +172,15 @@ namespace ECSPhysics2D
     private void SyncKinematicTransforms(ref SystemState state)
     {
       // Kinematic bodies: ECS drives physics transform
-      foreach (var (transform, bodyComponent, entity) in
+      foreach (var (transform, bodyComponent) in
           SystemAPI.Query<RefRO<LocalTransform>, RefRO<PhysicsBodyComponent>>()
-          .WithAll<PhysicsKinematicTag, PhysicsBodyInitialized>()
-          .WithEntityAccess()) {
+          .WithAll<PhysicsKinematicTag, PhysicsBodyInitialized>()) {
         if (!bodyComponent.ValueRO.IsValid)
           continue;
 
-        GetWorldSpacePosRot(entity, transform.ValueRO, out var position, out var rotation);
-
         var body = bodyComponent.ValueRO.Body;
-        body.position = position;
-        body.rotation = new PhysicsRotate(rotation);
+        body.position = transform.ValueRO.Position.xy;
+        body.rotation = PhysicsUtility.GetRotationZ(transform.ValueRO.Rotation);
       }
     }
 

--- a/Assets/ECSPhysics2D/Runtime/Core/Systems/ExportPhysicsWorldSystem.cs
+++ b/Assets/ECSPhysics2D/Runtime/Core/Systems/ExportPhysicsWorldSystem.cs
@@ -9,35 +9,20 @@ namespace ECSPhysics2D
   /// <summary>
   /// Exports physics simulation results back to ECS components.
   /// Runs after simulation to sync physics state TO ECS.
-  ///
+  /// 
   /// Each entity's transform is read from its assigned physics world
   /// (determined by PhysicsBodyComponent.WorldIndex).
-  ///
-  /// When a physics entity has a Parent component, the world-space position
-  /// returned by Box2D is converted to local space before writing to LocalTransform.
   /// </summary>
   [UpdateInGroup(typeof(FixedStepSimulationSystemGroup))]
   [UpdateAfter(typeof(PhysicsSimulationSystem))]
   [BurstCompile]
   public partial struct ExportPhysicsWorldSystem : ISystem
   {
-    private ComponentLookup<Parent> _parentLookup;
-    private ComponentLookup<LocalToWorld> _localToWorldLookup;
-
-    public void OnCreate(ref SystemState state)
-    {
-      _parentLookup = state.GetComponentLookup<Parent>(isReadOnly: true);
-      _localToWorldLookup = state.GetComponentLookup<LocalToWorld>(isReadOnly: true);
-    }
-
     [BurstCompile]
     public void OnUpdate(ref SystemState state)
     {
       if (!SystemAPI.TryGetSingleton<PhysicsWorldSingleton>(out var physicsWorldSingleton))
         return;
-
-      _parentLookup.Update(ref state);
-      _localToWorldLookup.Update(ref state);
 
       // Step 1: Sync Dynamic body transforms FROM physics
       SyncDynamicTransforms(ref state);
@@ -50,30 +35,23 @@ namespace ECSPhysics2D
     private void SyncDynamicTransforms(ref SystemState state)
     {
       // Dynamic bodies: Physics drives ECS transform
-      foreach (var (transform, bodyComponent, preservation, entity) in
+      foreach (var (transform, bodyComponent, preservation) in
           SystemAPI.Query<RefRW<LocalTransform>, RefRO<PhysicsBodyComponent>, RefRO<PhysicsTransformPreservation>>()
-          .WithAll<PhysicsDynamicTag, PhysicsBodyInitialized>()
-          .WithEntityAccess()) {
+          .WithAll<PhysicsDynamicTag, PhysicsBodyInitialized>()) {
         if (!bodyComponent.ValueRO.IsValid)
           continue;
 
         var body = bodyComponent.ValueRO.Body;
 
-        // Reconstruct world-space position (physics operates in XY; Z is preserved from creation)
-        var worldPos = new float3(body.position.x, body.position.y, preservation.ValueRO.ZPosition);
-        var worldRot = quaternion.RotateZ(body.rotation.angle);
+        // Update position (preserving Z)
+        transform.ValueRW.Position = new float3(
+            body.position.x,
+            body.position.y,
+            preservation.ValueRO.ZPosition
+        );
 
-        if (_parentLookup.TryGetComponent(entity, out var parent)) {
-          // Entity has a parent: convert world-space physics result to local space
-          var parentLTW = _localToWorldLookup[parent.Value];
-          var invParent = math.inverse(parentLTW.Value);
-          transform.ValueRW.Position = math.transform(invParent, worldPos);
-          transform.ValueRW.Rotation = math.mul(math.inverse(new quaternion(parentLTW.Value)), worldRot);
-        } else {
-          // Root entity: local space == world space
-          transform.ValueRW.Position = worldPos;
-          transform.ValueRW.Rotation = worldRot;
-        }
+        // Update rotation (2D rotation around Z axis)
+        transform.ValueRW.Rotation = quaternion.RotateZ(body.rotation.angle);
 
         // Scale is preserved from original value (physics doesn't affect scale)
         transform.ValueRW.Scale = preservation.ValueRO.Scale.x;

--- a/Assets/ECSPhysics2D/package.json
+++ b/Assets/ECSPhysics2D/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.ecsphysics2d.core",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "displayName": "ECSPhysics2D",
   "description": "ECSPhysics2D is an ECS-compatible wrapper for the UnityEngine.LowLevelPhysics2D Physics engine. The physics engine is struct-based, multithreaded, high performance, and out of the box DOTS compatible.",
   "unity": "6000.3",


### PR DESCRIPTION
## Summary

This PR reverts the changes from PR #8 ("Fix #7: account for Parent transform hierarchy in physics world systems").

After analysis, the `Parent`-aware coordinate conversion approach introduces more problems than it solves. **The correct design is for all physics entities to be root entities (no `Parent`)**, using Box2D joints to express physical relationships instead of ECS transform hierarchy.

## Why revert?

PR #8 attempted to bridge two fundamentally contradictory ownership models:

- **ECS `Parent`** says: _"My position is defined relative to my parent. The transform system owns my final world position."_
- **Box2D** says: _"I own this body's world position. I moved it according to forces, collisions, and constraints."_

When both are active on the same entity, there are **two masters** for the entity's position. The PR #8 fix mediated between them each frame — converting Box2D world-space results to parent-local space, then letting Unity's transform system re-compose them back. But this round-trip introduces several issues:

1. **Stale `LocalToWorld` on export:** `ExportPhysicsWorldSystem` runs _before_ `TransformSystemGroup` updates `LocalToWorld`. When it reads the parent's `LocalToWorld` to compute the inverse transform, it's using **last frame's data**. If the parent also moved this frame, the inverse transform is wrong — producing one-frame positional lag and jitter.

2. **Double-application of parent movement:** After export writes a local-space position computed from the parent's _old_ `LocalToWorld`, Unity's `TransformSystemGroup` re-composes using the parent's _new_ `LocalToWorld`. The child's final world position includes a spurious delta equal to the parent's movement this frame.

3. **Z-position mismatch:** `PhysicsTransformPreservation.ZPosition` stores `LocalTransform.Position.z` (local-space Z), but on export this value is used as part of the world-space position before being inverse-transformed. If the parent has non-zero Z, the result is incorrect.

4. **Scale not fully accounted for:** `math.inverse` on the parent's `float4x4` includes scale, but the child's scale is unconditionally overwritten from `preservation.Scale.x`, ignoring any parent scale changes.

5. **Added complexity for an anti-pattern:** The `ComponentLookup<Parent>`, `ComponentLookup<LocalToWorld>`, `GetWorldSpacePosRot` helper, and inverse-transform logic add meaningful complexity to what should be straightforward read/write systems.

## The correct approach: physics entities should be root entities

The ECS `Parent` concept is a **transform relationship**, not a physics one. Box2D has its own first-class mechanisms for expressing physical relationships between bodies:

| Desired behavior | `Parent` approach (reverted) | Physics-native approach |
|---|---|---|
| Child follows parent rigidly | Fragile — stale `LocalToWorld`, one-frame lag | **`WeldJoint`** — Box2D handles it natively |
| Child attached with flexibility | Not really possible — `Parent` is rigid | **`DistanceJoint`**, **`SpringJoint`**, etc. |
| Child responds to parent collisions | Indirect — only via transform propagation after export | Direct — joint transmits forces naturally |
| Multiple dynamic bodies in hierarchy | Broken — each body moves independently, then inverse transform fights re-composition | Just works — each body is independent in world space, joints express relationships |

### When to use `Parent`

`Parent` remains the right tool for **non-physics visual attachments**: health bars, particle emitters, shadow sprites, etc. These entities have no `PhysicsBodyComponent` — they just follow a physics entity's transform via the normal ECS hierarchy. No conflict arises.

### Edge case: baked subscene children

If a physics entity is authored as a child in a subscene/prefab, it will initially have a `Parent` and a local-space `LocalTransform`. The correct handling is a **one-shot conversion at creation time** — read `LocalToWorld` for the initial world position, then remove the `Parent` component so the entity becomes a root entity going forward. This is much simpler than ongoing per-frame reconciliation.

## What this revert does

- Removes `ComponentLookup<Parent>` and `ComponentLookup<LocalToWorld>` from both systems
- Removes the `GetWorldSpacePosRot` helper from `BuildPhysicsWorldSystem`
- Removes the inverse-parent-transform logic from `ExportPhysicsWorldSystem`
- Restores both systems to their original, simple form: read `LocalTransform` on import, write `LocalTransform` on export
- Removes the v0.1.3 changelog entry

## References

- Closes #7 (supersedes the original fix with the correct architectural approach)
- Reverts PR #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)