### PR TITLE
fix: guard against invalidated shapes in end/hit event loops (#14)

### DIFF
--- a/Assets/ECSPhysics2D/CHANGELOG.md
+++ b/Assets/ECSPhysics2D/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on \[Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to \[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## \[0.1.7] - 2026-05-19
+
+### Fixed
+
+- `PhysicsEventGatheringSystem` now guards against invalidated shape handles before accessing `.body` in the `contactEndEvents`, `contactHitEvents`, and `triggerEndEvents` loops; prevents a Unity warning when a body is destroyed mid-frame and Box2D emits end events for its now-invalid shapes
+
 ## \[0.1.6] - 2026-04-23
 
 ### Added

--- a/Assets/ECSPhysics2D/Runtime/Events/Systems/PhysicsEventGatheringSystem.cs
+++ b/Assets/ECSPhysics2D/Runtime/Events/Systems/PhysicsEventGatheringSystem.cs
@@ -121,6 +121,9 @@ namespace ECSPhysics2D
       for (int i = 0; i < endEvents.Length; i++) {
         var rawEvent = endEvents[i];
 
+        // shapes are invalidated when a body is destroyed mid-frame
+        if (!rawEvent.shapeA.isValid || !rawEvent.shapeB.isValid) { continue; }
+
         var evt = new CollisionEvent
         {
           EntityA = rawEvent.shapeA.body.GetEntityUserData(),
@@ -143,6 +146,9 @@ namespace ECSPhysics2D
       var hitEvents = world.contactHitEvents;
       for (int i = 0; i < hitEvents.Length; i++) {
         var rawEvent = hitEvents[i];
+
+        // shapes are invalidated when a body is destroyed mid-frame
+        if (!rawEvent.shapeA.isValid || !rawEvent.shapeB.isValid) { continue; }
 
         // Get full velocities at contact point
         float2 velA = GetVelocityAtPoint(rawEvent.shapeA.body, rawEvent.point);
@@ -235,6 +241,9 @@ namespace ECSPhysics2D
       var exitEvents = world.triggerEndEvents;
       for (int i = 0; i < exitEvents.Length; i++) {
         var rawEvent = exitEvents[i];
+
+        // shapes are invalidated when a body is destroyed mid-frame
+        if (!rawEvent.triggerShape.isValid || !rawEvent.visitorShape.isValid) { continue; }
 
         var evt = new TriggerEvent
         {

--- a/Assets/ECSPhysics2D/package.json
+++ b/Assets/ECSPhysics2D/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.ecsphysics2d.core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "displayName": "ECSPhysics2D",
   "description": "ECSPhysics2D is an ECS-compatible wrapper for the UnityEngine.LowLevelPhysics2D Physics engine. The physics engine is struct-based, multithreaded, high performance, and out of the box DOTS compatible.",
   "unity": "6000.3",


### PR DESCRIPTION
## Summary

Fixes #14.

When a `PhysicsBody` is destroyed mid-frame, Box2D emits `contactEndEvents` (and potentially `contactHitEvents` / `triggerEndEvents`) whose shape handles are immediately invalidated. `PhysicsEventGatheringSystem` was accessing `.body` on those handles without a validity check, triggering:

```
UnityEngine.LowLevelPhysics2D.PhysicsShape.body was called with an invalid argument 'PhysicsShape shape'
```

- Add `isValid` guard to the **`contactEndEvents`** loop — root cause of the reported warning
- Add `isValid` guard to the **`contactHitEvents`** loop — same latent risk
- Add `isValid` guard to the **`triggerEndEvents`** loop in `GatherTriggerEvents` — same latent risk

The `contactBeginEvents` loop already has a validity check (`rawEvent.contactId.isValid`) and is unaffected.

## Test plan

- [ ] Destroy a physics entity mid-frame using the documented pattern (`Body.Destroy()` + `ecb.DestroyEntity()`) and confirm the Unity warning no longer fires
- [ ] Confirm contact begin/end/hit and trigger enter/exit events still fire correctly for bodies that are *not* destroyed

Closes #14 

---
_Generated by [Claude Code](https://claude.ai/code/session_014nVxp23KUUL6TrhgTHrBnN)_